### PR TITLE
File Manager v1 Update 2023-04-20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 COPY --chown=www-data owncloud /tmp/owncloud
 RUN /tmp/owncloud/owncloud-install.sh --with-httpd && \
     rm -rf /tmp/owncloud && \
+    rm /var/www/owncloud/apps/files_external/3rdparty/composer.lock && \
     cp -r /var/www/owncloud/apps /etc/skel/owncloud
 
 RUN mkdir -p /etc/NAE && \
@@ -61,8 +62,7 @@ RUN apt-get purge -y \
     cmake* \
     cpp* \
     git \
-    xz-utils \
-    samba*
+    xz-utils
 
 RUN apt-get -y autoclean && \
     apt-get -y autoremove && \

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,29 +1,27 @@
-Copyright (c) 2019, Nimbix, Inc.
+Copyright (c) 2023, Nimbix, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
- 
+modification, are permitted provided that the following conditions are met:
+
 1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer. 
+   this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
-The views and conclusions contained in the software and documentation are 
-those of the authors and should not be interpreted as representing official 
+The views and conclusions contained in the software and documentation are
+those of the authors and should not be interpreted as representing official
 policies, either expressed or implied, of Nimbix, Inc.
-
-

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 owncloud:
-	DOCKER_BUILDKIT=1 docker build --pull --rm -f "Dockerfile" -t us-docker.pkg.dev/jarvice-apps/images/filemanager:oc10.9-20230413 "." 2>&1 | tee build.log
+	DOCKER_BUILDKIT=1 docker build --pull --rm -f "Dockerfile" -t us-docker.pkg.dev/jarvice-apps/images/filemanager:oc10.9-20230420 "." 2>&1 | tee build.log
 
 push: owncloud
-	docker push us-docker.pkg.dev/jarvice-apps/images/filemanager:oc10.9-20230413
+	docker push us-docker.pkg.dev/jarvice-apps/images/filemanager:oc10.9-20230420

--- a/owncloud/nimbix-theme/defaults.php
+++ b/owncloud/nimbix-theme/defaults.php
@@ -123,7 +123,7 @@ class OC_Theme {
 			return '';
 		}
 	}
-	
+
 	public function getImprintUrl() {
 		try {
 			return \OC::$server->getConfig()->getAppValue('core', 'legal.imprint_url', '');
@@ -135,14 +135,14 @@ class OC_Theme {
 	public function getL10n() {
 		return \OC::$server->getL10N('core');
 	}
-	
+
 	/**
 	 * Returns short version of the footer
 	 * @return string short footer
 	 */
 	public function getShortFooter() {
 		$l10n = $this->getL10n();
-		$footer = '© 2019 <a href="'.$this->getBaseUrl().'" target="_blank\">'.$this->getEntity().'</a>'.
+		$footer = '© 2023 <a href="'.$this->getBaseUrl().'" target="_blank\">'.$this->getEntity().'</a>'.
 			'<br/>' . $this->getSlogan();
 		if ($this->getImprintUrl() !== '') {
 			$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '" target="_blank">' . $l10n->t('Imprint') . '</a></span>';
@@ -160,7 +160,7 @@ class OC_Theme {
 	 */
 	public function getLongFooter() {
 		$l10n = $this->getL10n();
-		$footer = '© 2019 <a href="'.$this->getBaseUrl().'" target="_blank\">'.$this->getEntity().'</a>'.
+		$footer = '© 2023 <a href="'.$this->getBaseUrl().'" target="_blank\">'.$this->getEntity().'</a>'.
 			'<br/>' . $this->getSlogan();
 		if ($this->getImprintUrl() !== '') {
 			$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '" target="_blank">' . $l10n->t('Imprint') . '</a></span>';


### PR DESCRIPTION
* Samba in no longer deleated as doing so caused many warnings to be seen in the logs.

* Copyright footers have been updated to say 2023.

* Removes a composer.lock file containing links to php 5.5.1. This is to stop wh's sec team from flaging the app with multiple crit issues.